### PR TITLE
Upload tarball with the release

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.2.2-dev
 #
 name: Create Release
 on:
@@ -232,3 +232,45 @@ jobs:
 
           git branch $release_branch HEAD^
           git push origin $release_branch
+
+  create_and_upload_build_artifacts:
+    name: Create and upload build artifacts
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        platform:
+          - darwin
+          - linux
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GO_VERSION: 1.14.2
+      ARTIFACT_DIR: bin-dist
+      TAG: v${{ needs.gather_facts.outputs.version }}
+    needs:
+      - create_release
+      - gather_facts
+    steps:
+      - name: Install architect
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: "architect"
+          version: "3.0.5"
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TAG }}
+      - name: Create ${{ matrix.platform }} package
+        run: make package-${{ matrix.platform }}
+      - name: Add ${{ matrix.platform }} package to release
+        uses: actions/upload-release-asset@v1
+        env:
+          FILE_NAME: ${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}-amd64.tar.gz
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ env.ARTIFACT_DIR }}/${{ env.FILE_NAME }}
+          asset_name: ${{ env.FILE_NAME }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.2.2-dev
 #
 name: Create Release PR
 on:

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.2.2-dev
 #
 name: gitleaks
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.2.2-dev
 #
 
 include Makefile.*.mk

--- a/Makefile.gen.app.mk
+++ b/Makefile.gen.app.mk
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.2.2-dev
 #
 
 .PHONY: lint-chart

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -1,7 +1,9 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.2.2-dev
 #
+
+PACKAGE_DIR    := ./bin-dist
 
 APPLICATION    := $(shell go list -m | cut -d '/' -f 3)
 BUILDTIMESTAMP := $(shell date -u '+%FT%TZ')
@@ -45,6 +47,24 @@ $(APPLICATION)-linux: $(APPLICATION)-v$(VERSION)-linux-amd64
 $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 	@echo "====> $@"
 	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+
+.PHONY: package-darwin package-linux
+## package-darwin: prepares a packaged darwin/amd64 version
+package-darwin: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz
+	@echo "====> $@"
+## package-linux: prepares a packaged linux/amd64 version
+package-linux: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz
+	@echo "====> $@"
+
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERSION)-%-amd64
+	@echo "====> $@"
+	mkdir -p $(DIR)
+	cp $< $(DIR)/$(APPLICATION)
+	cp README.md LICENSE $(DIR)
+	tar -C $(PACKAGE_DIR) -cvzf $(PACKAGE_DIR)/$<.tar.gz $<
+	rm -rf $(DIR)
+	rm -rf $<
 
 .PHONY: install
 ## install: install the application


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15611

I generated that with WIP version of devctl allowing to specify multiple flavours.
See https://github.com/giantswarm/devctl/pull/219

I'd like to unblock @kubasobon before doing whole devctl -> g/g dance.

After its merged the next release of config-controller should have downloadable tarball attached.