### PR TITLE
Throw errors when a template key is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Throw errors when template keys are missing.
+
 ## [0.2.3] - 2021-01-28
 
 ### Fixed

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -347,7 +347,7 @@ func (g Generator) renderTemplate(ctx context.Context, templateText string, temp
 	funcMap := sprig.FuncMap()
 	funcMap["include"] = g.include
 
-	t, err := template.New("main").Funcs(funcMap).Parse(templateText)
+	t, err := template.New("main").Funcs(funcMap).Option("missingkey=error").Parse(templateText)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -368,7 +368,7 @@ func (g Generator) include(templateName string, templateData interface{}) (strin
 		return "", microerror.Mask(err)
 	}
 
-	t, err := template.New(templateName).Funcs(sprig.FuncMap()).Parse(string(contents))
+	t, err := template.New(templateName).Funcs(sprig.FuncMap()).Option("missingkey=error").Parse(string(contents))
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -103,6 +103,16 @@ func TestGenerator_generateRawConfig(t *testing.T) {
 			installation:     "puma",
 			decryptTraverser: &mapStringTraverser{},
 		},
+
+		{
+			name:                 "case 9 - throw error when a key is missing",
+			caseFile:             "testdata/case9.yaml",
+			expectedErrorMessage: `<.this.key.is.missing>: map has no entry for key "this"`,
+
+			app:              "operator",
+			installation:     "puma",
+			decryptTraverser: &mapStringTraverser{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -14,8 +14,9 @@ import (
 
 func TestGenerator_generateRawConfig(t *testing.T) {
 	testCases := []struct {
-		name     string
-		caseFile string
+		name                 string
+		caseFile             string
+		expectedErrorMessage string
 
 		app          string
 		installation string
@@ -126,8 +127,19 @@ func TestGenerator_generateRawConfig(t *testing.T) {
 			}
 
 			configmap, secret, err := g.generateRawConfig(context.Background(), tc.app)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+			if tc.expectedErrorMessage == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+				}
+			} else {
+				switch {
+				case err == nil:
+					t.Fatalf("expected error %q but got nil", tc.expectedErrorMessage)
+				case !strings.Contains(microerror.Pretty(err, true), tc.expectedErrorMessage):
+					t.Fatalf("expected error %q but got %q", tc.expectedErrorMessage, microerror.Pretty(err, true))
+				default:
+					return
+				}
 			}
 			if configmap != fs.ExpectedConfigmap {
 				t.Fatalf("configmap not expected, got: %s", configmap)

--- a/pkg/generator/testdata/case9.yaml
+++ b/pkg/generator/testdata/case9.yaml
@@ -1,0 +1,19 @@
+path: default/config.yaml
+data: |
+  universalValue: 42
+---
+path: installations/puma/secret.yaml
+data: |
+  key: password
+---
+path: installations/puma/config.yaml.patch
+data: |
+  provider:
+    kind: aws
+    region: us-east-1
+---
+path: default/apps/operator/configmap-values.yaml.template
+data: |
+  answer: {{ .universalValue }}
+  region: {{ .provider.region }}
+  missing: {{ .this.key.is.missing }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15651


**Before**
```
~ ./config-controller generate --app aws-operator --github-token $OPSCTL_GITHUB_TOKEN --installation ginger  --config-version lint-errors
Error: Error making API request.

URL: POST https://127.0.0.1:33071/v1/transit/decrypt/config
Code: 400. Errors:
* invalid ciphertext: could not decode base64
```

**After**
```
~ ./config-controller generate --app aws-operator --github-token $OPSCTL_GITHUB_TOKEN --installation ginger  --config-version lint-errors
Error: Template: main:2:18: executing "main" at <.kuba.not.configured>: map has no entry for key "kuba"
```


## Checklist

- [x] Update changelog in CHANGELOG.md.
