### PR TITLE
Allow for raw config generation from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow for raw config generation from CLI.
+
 ## [0.2.10] - 2021-04-13
 
 ### Fixed

--- a/cmd/generate/flag.go
+++ b/cmd/generate/flag.go
@@ -15,6 +15,7 @@ const (
 	flagInstallation  = "installation"
 	flagName          = "name"
 	flagNamespace     = "namespace"
+	flagRaw           = "raw"
 	flagVerbose       = "verbose"
 
 	envConfigControllerGithubToken = "CONFIG_CONTROLLER_GITHUB_TOKEN" //nolint:gosec
@@ -27,6 +28,7 @@ type flag struct {
 	Installation  string
 	Name          string
 	Namespace     string
+	Raw           bool
 	Verbose       bool
 }
 
@@ -37,6 +39,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Installation, flagInstallation, "", `Installation codename (e.g. "gauss").`)
 	cmd.Flags().StringVar(&f.Name, flagName, "giantswarm", `Name of the generated ConfigMap/Secret.`)
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "giantswarm", `Namespace of the generated ConfigMap/Secret.`)
+	cmd.Flags().BoolVar(&f.Raw, flagRaw, false, `Forces generator to output YAML instead of ConfigMap & Secret.`)
 	cmd.Flags().BoolVar(&f.Verbose, flagVerbose, false, `Enables generator to output consecutive generation stages.`)
 }
 

--- a/cmd/generate/runner.go
+++ b/cmd/generate/runner.go
@@ -82,7 +82,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		ExtraLabels: nil,
 	}
 
-	configmap, secret, err := gen.Generate(ctx, in)
+	var configmap, secret interface{}
+
+	if r.flag.Raw {
+		configmap, secret, err = gen.GenerateRaw(ctx, in)
+	} else {
+		configmap, secret, err = gen.Generate(ctx, in)
+	}
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/generate/runner.go
+++ b/cmd/generate/runner.go
@@ -82,15 +82,17 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		ExtraLabels: nil,
 	}
 
-	var configmap, secret interface{}
-
-	if r.flag.Raw {
-		configmap, secret, err = gen.GenerateRaw(ctx, in)
-	} else {
-		configmap, secret, err = gen.Generate(ctx, in)
-	}
+	configmap, secret, err := gen.Generate(ctx, in)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+
+	if r.flag.Raw {
+		fmt.Println("---")
+		fmt.Printf(string(configmap.Data["configmap-values.yaml"]) + "\n")
+		fmt.Println("---")
+		fmt.Printf(string(secret.Data["secret-values.yaml"]) + "\n")
+		return nil
 	}
 
 	fmt.Println("---")


### PR DESCRIPTION
This can be useful for testing helm charts. Just append `--raw` flag to `config-controller generate` call.

## Checklist

- [x] Update changelog in CHANGELOG.md.
