### PR TITLE
Use app.unique=true by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `unique` app configuration to `true` by default.
+
 ## [0.3.1] - 2021-06-02
 
 ### Fixed

--- a/helm/config-controller/templates/_resource.tpl
+++ b/helm/config-controller/templates/_resource.tpl
@@ -22,11 +22,3 @@ room for such suffix.
 {{- define "resource.pullSecret.name" -}}
 {{- include "resource.default.name" . -}}-pull-secret
 {{- end -}}
-
-{{/*
-The unique deployment for Management Cluster uses a special app version of
-0.0.0.
-*/}}
-{{- define "resource.app.unique" -}}
-{{- if hasSuffix "-unique" .Release.Name }}true{{ else }}false{{ end }}
-{{- end -}}

--- a/helm/config-controller/templates/configmap.yaml
+++ b/helm/config-controller/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
         address: 'http://0.0.0.0:8000'
     service:
       app:
-        unique: {{ include "resource.app.unique" . }}
+        unique: true
       installation:
         name: {{ .Values.managementCluster.name }}
       kubernetes:


### PR DESCRIPTION
We've dropped `-unique` suffix so this check now sets unique to false and breaks CR reconciliation.
We don't have this controller as non-unique app anywhere so we can set it to true by default

## Checklist

- [x] Update changelog in CHANGELOG.md.
