### PR TITLE
Fix fetching the latest tag for a version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a flag to allow the user to be passed to `opsctl` when generating locally.
 
+### Fixed
+
+- Fix fetching the latest tag for a version range.
+
 ## [0.3.2] - 2021-06-03
 
 ### Changed

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -104,7 +104,7 @@ func (g *GitHub) getTags(ctx context.Context, owner, name, filter string) ([]str
 	const query = `
 		query($owner:String!, $name:String!, $filter:String!, $after:String) {
 		  repository(name: $name, owner: $owner) {
-		    refs(first: 100, refPrefix: "refs/tags/", after: $after, query: $filter, direction: ASC) {
+		    refs(first: 100, refPrefix: "refs/tags/", after: $after, query: $filter, direction: DESC) {
 		      edges {
 		        cursor
 		        node {


### PR DESCRIPTION
This is not the most beautiful fix, but it fixes the problem. When the order is changed to descending it finds the latest tag. The problem is it is still limiting the number of results to 100. But it should be ok, or at least better.

Original discussion: https://gigantic.slack.com/archives/C02EVLE9W/p1628150603050600