### PR TITLE
Add use of the runtime/default seccomp profile.

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,31 +1,18 @@
-# pkg:golang/github.com/hashicorp/consul/sdk@v0.9.0
-CVE-2022-29153 until=2022-12-31
-CVE-2022-24687 until=2022-12-31
+# pkg:golang/github.com/hashicorp/consul/api@v1.15.3
+CVE-2022-29153 until=2023-06-30
 
-# pkg:golang/github.com/hashicorp/consul/api@v1.12.0
-CVE-2021-41803 until=2022-12-31
+# pkg:golang/github.com/hashicorp/consul/sdk@v0.3.0
+CVE-2022-29153 until=2023-06-30
 
 # pkg:golang/github.com/kataras/iris/v12@v12.1.8
-CVE-2021-23772 until=2022-12-31
+CVE-2021-23772 until=2023-06-30
 
-# pkg:golang/k8s.io/apiserver@v0.24.3
-# This is present in the current latest v0.26.0 as well
-sonatype-2022-6522 until=2023-02-01
+# pkg:golang/github.com/nats-io/nats-server/v2@v2.9.0
+CVE-2022-42709 until=2023-06-30
+CVE-2022-42708 until=2023-06-30
 
 # pkg:golang/github.com/urfave/negroni@v1.0.0
-sonatype-2021-1485 until=2022-12-31
-
-# pkg:golang/github.com/nats-io/nats-server/v2@v2.5.0
-CVE-2022-42709 until=2022-12-31
-CVE-2022-42708 until=2022-12-31
+sonatype-2021-1485 until=2023-06-30
 
 # pkg:golang/k8s.io/apiserver@v0.24.3
-# The current latest v0.26.0 has the same issue
-sonatype-2022-6522 until=2023-02-01
-
-# pkg:golang/golang.org/x/text@v0.3.7
-CVE-2022-32149 until=2022-12-31
-
-# pkg:golang/github.com/hashicorp/vault/sdk@v0.5.3
-# pkg:golang/github.com/hashicorp/vault/api@v1.7.2
-CVE-2022-36129 until=2022-12-31
+sonatype-2022-6522 until=2023-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add use of the runtime/default seccomp profile.
+
 ## [0.6.0] - 2022-07-21
 
 ### Changed

--- a/helm/config-controller/templates/deployment.yaml
+++ b/helm/config-controller/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       initContainers:
       - args:
         - --vault-address={{ .Values.vault.address }}
@@ -89,6 +92,10 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 1
+        securityContext:
+          {{- with .Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
         resources:
           requests:
             cpu: 100m

--- a/helm/config-controller/templates/psp.yaml
+++ b/helm/config-controller/templates/psp.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "resource.psp.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/config-controller/values.schema.json
+++ b/helm/config-controller/values.schema.json
@@ -1,0 +1,118 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "github": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "k8sJwtToVaultTokenImage": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "managementCluster": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "pod": {
+            "type": "object",
+            "properties": {
+                "group": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "registry": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string"
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "vault": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/helm/config-controller/values.yaml
+++ b/helm/config-controller/values.yaml
@@ -26,3 +26,13 @@ vault:
 
 github:
   token: ""
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible.
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.