### PR TITLE
Add missing team label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing team label on the service monitor and all helm resources.
+
 ## [0.10.0] - 2024-02-20
 
 ### Added

--- a/helm/config-controller/templates/_helpers.tpl
+++ b/helm/config-controller/templates/_helpers.tpl
@@ -23,6 +23,7 @@ app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 


### PR DESCRIPTION
This PR add the missing team label on all of this chart resources to make sure.
This is really only needed for the service monitor to be picked up by the proper prometheus but having it everywhere is the norm

## Checklist

- [x] Update changelog in CHANGELOG.md.
